### PR TITLE
🐛 bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ it has breaking changes.
 
 ## Installation and requirements
 
-The package requires Go v1.11 or later.
+The package requires Go v1.12 or later.
 
 To install the package use `go get github.com/workanator/go-floc/v3`
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/workanator/go-floc/v3
 
-go 1.11
+go 1.12

--- a/result_mask_test.go
+++ b/result_mask_test.go
@@ -7,18 +7,23 @@ import (
 func TestEmptyResultMask(t *testing.T) {
 	set := EmptyResultMask()
 	results := []Result{None, Completed, Canceled, Failed}
+
 	length := len(results)
-	maskeds := make(chan bool, length)
-	for _, r := range results {
-		go func(r Result) {
-			maskeds <- set.IsMasked(r)
-		}(r)
+	maskeds := make(chan int, length)
+	for idx, r := range results {
+		go func(n int, r Result) {
+			if set.IsMasked(r) {
+				maskeds <- n
+			} else {
+				maskeds <- -1
+			}
+		}(idx, r)
 	}
 
 	for i := 0; i < length; i++ {
-		flag := <-maskeds
-		if flag {
-			t.Fatalf("%s expects %s to be not masked", t.Name(), results[i].String())
+		index := <-maskeds
+		if index >= 0 {
+			t.Fatalf("%s expects %s to be not masked", t.Name(), results[index].String())
 		}
 	}
 }

--- a/result_mask_test.go
+++ b/result_mask_test.go
@@ -1,16 +1,25 @@
 package floc
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestEmptyResultMask(t *testing.T) {
 	set := EmptyResultMask()
-
-	for _, r := range []Result{None, Completed, Canceled, Failed} {
+	results := []Result{None, Completed, Canceled, Failed}
+	length := len(results)
+	maskeds := make(chan bool, length)
+	for _, r := range results {
 		go func(r Result) {
-			if set.IsMasked(r) {
-				t.Fatalf("%s expects %s to be not masked", t.Name(), r.String())
-			}
+			maskeds <- set.IsMasked(r)
 		}(r)
+	}
+
+	for i := 0; i < length; i++ {
+		flag := <-maskeds
+		if flag {
+			t.Fatalf("%s expects %s to be not masked", t.Name(), results[i].String())
+		}
 	}
 }
 


### PR DESCRIPTION
<img width="770" alt="Screenshot 2021-08-10 at 12 16 12 PM" src="https://user-images.githubusercontent.com/28108597/128807375-2513de0c-9ea3-4de3-a976-a477c05d1915.png">
<img width="857" alt="Screenshot 2021-08-10 at 12 12 38 PM" src="https://user-images.githubusercontent.com/28108597/128807413-e0c28467-44fd-4e03-9fa4-5e42bc564ea9.png">

We have several issue on the `v3` released
- **Checksum mismatch** (after investigation, this is probably due to some breaking changes on go 1.11.3 and go 1.11.4)
- **Improper test case** (test doesn't handle correctly, the routine will escape the test result)

Basically, my PR will fixed the checksum mismatch and test case issue, this had been tested and proved to work.

